### PR TITLE
Re-render after gcc and clang update and bump version to 1.6.0

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: win
   pool:
-    vmImage: windows-2019
+    vmImage: windows-2022
   strategy:
     matrix:
       win_64_:
@@ -36,7 +36,7 @@ jobs:
 
     - script: |
         call activate base
-        mamba.exe install "python=3.9" conda-build conda pip boa conda-forge-ci-setup=3 "py-lief<0.12" -c conda-forge --strict-channel-priority --yes
+        mamba.exe install "python=3.10" conda-build conda pip boa conda-forge-ci-setup=3 -c conda-forge --strict-channel-priority --yes
       displayName: Install conda-build
 
     - script: set PYTHONUNBUFFERED=1

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,13 +11,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -15,13 +15,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos7
 channel_sources:
@@ -11,13 +11,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,13 +11,13 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 llvm_openmp:
-- '14'
+- '15'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,13 +11,13 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 llvm_openmp:
-- '14'
+- '15'
 macos_machine:
 - arm64-apple-darwin20.0.0
 target_platform:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -24,9 +24,9 @@ source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
 
 mamba install --update-specs --quiet --yes --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,33 @@
+About compilers-feedstock
+=========================
+
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/compilers-feedstock/blob/main/LICENSE.txt)
+
 About compilers
-===============
+---------------
+
+Home: https://conda-forge.org
+
+Package license: BSD-3-Clause
+
+Summary: A metapackage to obtain compilers
+
+This package is a generic way to obtain the compilers for your system
+that conda-forge used to compile its ecosystem. These compilers are,
+therefore, guaranteed to be ABI compatible with the conda packages
+you have installed.
+
+These compiler metapackages are a convenience ONLY for users.
+Do NOT use these packages as a build or host dependencies in other
+recipes.  Use the compiler Jinja template function instead.
+For C++ for example, use compiler('cxx') as usual.
+
+About c-compiler
+----------------
 
 Home: https://conda-forge.org
 
 Package license: BSD
-
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/compilers-feedstock/blob/main/LICENSE.txt)
 
 Summary: A metapackage to obtain a C compiler
 
@@ -17,6 +39,42 @@ you have installed.
 This compiler metapackage is a convenience ONLY for users.
 Do NOT use this package as a build or host dependency in other
 recipes.  Use the Jinja template function compiler('c') instead.
+
+About cxx-compiler
+------------------
+
+Home: https://conda-forge.org
+
+Package license: BSD
+
+Summary: A metapackage to obtain a C++ compiler
+
+This package is a generic way to obtain the C++ compiler for your system
+that conda-forge used to compile its ecosystem.  This compiler is,
+therefore, guaranteed to be ABI compatible with the conda packages
+you have installed.
+
+This compiler metapackage is a convenience ONLY for users.
+Do NOT use this package as a build or host dependency in other
+recipes.  Use the Jinja template function compiler('cxx') instead.
+
+About fortran-compiler
+----------------------
+
+Home: https://conda-forge.org
+
+Package license: BSD
+
+Summary: A metapackage to obtain a Fortran compiler
+
+This package is a generic way to obtain the Fortran compiler for your
+system that conda-forge used to compile its ecosystem.  This compiler
+is, therefore, guaranteed to be ABI compatible with the conda packages
+you have installed.
+
+This compiler metapackage is a convenience ONLY for users.
+Do NOT use this package as a build or host dependency in other
+recipes.  Use the Jinja template function compiler('fortran') instead.
 
 
 Current build status
@@ -221,7 +279,4 @@ Feedstock Maintainers
 * [@duncanmmacleod](https://github.com/duncanmmacleod/)
 * [@isuruf](https://github.com/isuruf/)
 * [@scopatz](https://github.com/scopatz/)
-
-
-<!-- dummy commit to enable rerendering -->
 

--- a/README.md
+++ b/README.md
@@ -222,3 +222,6 @@ Feedstock Maintainers
 * [@isuruf](https://github.com/isuruf/)
 * [@scopatz](https://github.com/scopatz/)
 
+
+<!-- dummy commit to enable rerendering -->
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@
 
 package:
   name: compilers
-  version: 1.5.2
+  version: 1.6.0
 
 build:
    number: 0


### PR DESCRIPTION
gcc was updated from 11 to 12 and clang was updated from 14 to 15 in https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/4215, this re-render propagates the same change to the `compilers` package.


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
